### PR TITLE
Fix mouse input occasionally not working

### DIFF
--- a/src/firmware/QuokkADB-supplementary-files/launch.json
+++ b/src/firmware/QuokkADB-supplementary-files/launch.json
@@ -9,12 +9,12 @@
             "type": "cortex-debug",
             "servertype": "openocd",
             // this is using https://github.com/raspberrypi/openocd compiled locally
-            "serverpath": "${env:HOME}/openocd/src/openocd",
+            "serverpath": "openocd",
             // This may need to be arm-none-eabi-gdb depending on your system
             "gdbPath" : "gdb-multiarch",
             "device": "RP2040",
             "configFiles": [
-                "interface/picoprobe.cfg",
+                "interface/cmsis-dap.cfg",
                 "target/rp2040.cfg"
             ],
             "svdFile": "${env:PICO_SDK_PATH}/src/rp2040/hardware_regs/rp2040.svd",
@@ -24,7 +24,7 @@
                 "break main",
                 "continue"
             ],
-            "searchDir": ["${env:HOME}/openocd/tcl"],
+            "searchDir": ["usr/local/share/openocd/scripts"],
         }
     ]
 }

--- a/src/firmware/lib/QuokkADB/src/adb_platform.cpp
+++ b/src/firmware/lib/QuokkADB/src/adb_platform.cpp
@@ -27,6 +27,10 @@
 #include "hardware/gpio.h"
 #include <time.h>
 
+extern volatile bool adb_collision;
+extern volatile bool collision_detection;
+extern ADBKbdRptParser KeyboardPrs;
+
 bool AdbInterfacePlatform::adb_delay_us(uint32_t delay) 
 {
   uint64_t start = time_us_64();
@@ -43,10 +47,6 @@ bool AdbInterfacePlatform::adb_delay_us(uint32_t delay)
   
   return collision_free;
 }
-
-extern volatile bool adb_collision;
-extern volatile bool collision_detection;
-extern ADBKbdRptParser KeyboardPrs;
 
 static void adb_in_irq_callback(uint gpio, uint32_t event_mask) {
     // a possible collision occurs when ABD is meant to be high

--- a/src/firmware/lib/QuokkADB/src/platformkbdparser.cpp
+++ b/src/firmware/lib/QuokkADB/src/platformkbdparser.cpp
@@ -201,10 +201,10 @@ bool PlatformKbdParser::SpecialKeyCombo(KBDINFO *cur_kbd_info)
                         else
                         {
                                 SendString("Busy LED is off");
-                        }                 
-                break;        
+                        }
+                break;
                 }
-                
+
                 return true;
         }
         return false;

--- a/src/firmware/lib/adb/src/adb.cpp
+++ b/src/firmware/lib/adb/src/adb.cpp
@@ -59,8 +59,6 @@ volatile bool collision_detection = false;
 bool mouse_skip_next_listen_reg3 = false;
 bool kbd_skip_next_listen_reg3 = false;
 
-
-
 extern bool global_debug;
 // The original data_lo code would just set the bit as an output
 // That works for a host, since the host is doing the pullup on the ADB line,
@@ -297,7 +295,17 @@ void AdbInterface::ProcessCommand(int16_t cmd)
               }
               break;
             }
-            mouse_addr = listen_addr;
+
+            // Moving to address 0 can cause issues as it is normally reserved for the host
+            if (listen_addr == 0)
+            {
+              break;
+            }
+            else
+            {
+              mouse_addr = listen_addr;
+            }
+
             if (global_debug)
             {
               Serial.print("MOUSE: address change to 0x");
@@ -473,7 +481,17 @@ void AdbInterface::ProcessCommand(int16_t cmd)
               }
               break;
             }
-            kbd_addr = listen_addr;
+
+            // Moving to address 0 can cause issues as it is normally reserved for the host
+            if ( listen_addr == 0 )
+            {
+              break;
+            }
+            else
+            {
+              kbd_addr = listen_addr;
+            }
+
             if (global_debug)
             {
               Serial.print("KBD: address change to 0x");
@@ -612,8 +630,6 @@ void AdbInterface::ProcessCommand(int16_t cmd)
 uint16_t AdbInterface::GetAdbRegister3Keyboard()
 {
   uint16_t kbdreg3 = 0;
-  // using random address 
-  uint8_t random_address = rand() & 0xF;
   // Bit 15 Reserved; must be 0
   B_UNSET(kbdreg3, 15);
   // 14      Exceptional event, device specific; always 1 if not used
@@ -625,6 +641,12 @@ uint16_t AdbInterface::GetAdbRegister3Keyboard()
   // 11-8      Device address
   // "ADB - The Untold Story: Space Aliens Ate My Mouse"
   // specifies that a random value should be returned as the address for register 3
+  static uint8_t random_address = 0xFF;
+  if (random_address == 0xFF)
+  {
+    random_address = rand() & 0xF;
+  }
+
   kbdreg3 |=  random_address << 8;
   // 7-0       Device Handler ID
   kbdreg3 |= kbd_handler_id;
@@ -634,8 +656,6 @@ uint16_t AdbInterface::GetAdbRegister3Keyboard()
 uint16_t AdbInterface::GetAdbRegister3Mouse()
 {
   uint16_t mousereg3 = 0;
-  // using random address in 0x8 to 0xE addresses
-  uint8_t random_address =  rand() & 0xF;
   // Bit 15 Reserved; must be 0
   B_UNSET(mousereg3, 15);
   // 14      Exceptional event, device specific; always 1 if not used
@@ -647,6 +667,11 @@ uint16_t AdbInterface::GetAdbRegister3Mouse()
   // 11-8      Device address 
   // "ADB - The Untold Story: Space Aliens Ate My Mouse"
   // specifies that a random value should be returned as the address for register 3
+  static uint8_t random_address = 0xFF;
+  if (random_address == 0xFF)
+  {
+    random_address = rand() & 0xF;
+  }
   mousereg3 |= random_address << 8;  
   // 7-0       Device Handler ID
   mousereg3 |= mouse_handler_id;


### PR DESCRIPTION
The issue is the Mouse get assigned to ADB address 0, where the OS doesn't recognize the mouse input. The fix is to skip listen reg3 address assignment when the ADB host tries to assign it to address 0.